### PR TITLE
Configure Tailwind CSS support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
     "@types/node": "20.14.10",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.4",
+    "postcss": "8.4.39",
+    "tailwindcss": "3.4.4",
     "typescript": "5.4.5"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Tailwind CSS, PostCSS, and Autoprefixer development dependencies
- create Tailwind and PostCSS configuration files following the Next.js setup guide
- enable Tailwind CSS directives in the global stylesheet

## Testing
- npm run lint *(fails: `next` command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e475a9e700832b81de3c77b9167e85