### PR TITLE
chore: configure eslint and prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["next/core-web-vitals"]
+  "root": true,
+  "extends": ["next/core-web-vitals", "prettier"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+out
+build
+coverage
+
+# Logs
+*.log
+
+# Generated files
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "next": "14.2.4",
@@ -25,7 +26,9 @@
     "autoprefixer": "10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.4",
+    "eslint-config-prettier": "9.1.0",
     "postcss": "8.4.39",
+    "prettier": "3.3.2",
     "tailwindcss": "3.4.4",
     "typescript": "5.4.5"
   }


### PR DESCRIPTION
## Summary
- configure ESLint to extend the Prettier configuration
- add Prettier configuration and ignore files
- add lint and format npm scripts for consistency

## Testing
- not run (npm registry access denied in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4784c9980832b8aa7f7704ab6eb19