### PR TITLE
Add dashboard UI building blocks

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground shadow", // Default filled badge
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        destructive: "border-transparent bg-destructive text-destructive-foreground shadow",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+  const { className, variant, size, ...rest } = props;
+  return (
+    <button
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...rest}
+    />
+  );
+});
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-xl border bg-card text-card-foreground shadow", className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      {...props}
+    />
+  ),
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref as React.Ref<HTMLHeadingElement>}
+      className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  ),
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p
+      ref={ref}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  ),
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("p-6 pt-0", className)}
+      {...props}
+    />
+  ),
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    />
+  ),
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/features/dashboard/components/critical-alert-card.tsx
+++ b/src/features/dashboard/components/critical-alert-card.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { AlertTriangle } from "lucide-react";
+import type { CriticalAlert } from "../types";
+
+export interface CriticalAlertCardProps {
+  alert: CriticalAlert;
+  onAcknowledge?: (alert: CriticalAlert) => void;
+  onResolve?: (alert: CriticalAlert) => void;
+  className?: string;
+}
+
+export function CriticalAlertCard({
+  alert,
+  onAcknowledge,
+  onResolve,
+  className,
+}: CriticalAlertCardProps) {
+  const severityClasses: Record<CriticalAlert["severity"], string> = {
+    critical: "border-rose-500/50 bg-rose-500/10",
+    warning: "border-amber-500/50 bg-amber-500/10",
+  };
+
+  const statusLabels: Record<CriticalAlert["status"], string> = {
+    active: "Ativo",
+    acknowledged: "Reconhecido",
+    resolved: "Resolvido",
+  };
+
+  return (
+    <Card className={cn("h-full border backdrop-blur", severityClasses[alert.severity], className)}>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full border border-current/40 bg-background/60 p-2 text-foreground">
+            <AlertTriangle className="h-5 w-5" />
+          </span>
+          <div>
+            <CardTitle className="text-lg font-semibold leading-tight">{alert.alertType}</CardTitle>
+            <CardDescription className="text-xs uppercase tracking-wide">{alert.siloName}</CardDescription>
+          </div>
+        </div>
+        <Badge variant="secondary" className="bg-background/50 text-current">
+          {statusLabels[alert.status]}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm text-muted-foreground">
+        <div className="grid gap-2 sm:grid-cols-2">
+          <InfoItem label="Detectado em" value={alert.detectedAt} />
+          <InfoItem label="Duração" value={`${alert.durationMinutes} min`} />
+          <InfoItem label="Severidade" value={alert.severity === "critical" ? "Crítico" : "Aviso"} />
+          <InfoItem label="Recomendação" value={alert.recommendedAction} />
+        </div>
+        <p className="rounded-lg border border-border/60 bg-background/60 p-3 text-foreground">
+          {alert.description}
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {onAcknowledge && (
+            <Button size="sm" variant="outline" onClick={() => onAcknowledge(alert)}>
+              Registrar reconhecimento
+            </Button>
+          )}
+          {onResolve && (
+            <Button size="sm" onClick={() => onResolve(alert)}>
+              Marcar como resolvido
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface InfoItemProps {
+  label: string;
+  value: string;
+}
+
+function InfoItem({ label, value }: InfoItemProps) {
+  return (
+    <div className="flex flex-col rounded-lg border border-border/50 bg-background/60 p-3">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">{label}</span>
+      <span className="text-sm font-semibold text-foreground">{value}</span>
+    </div>
+  );
+}

--- a/src/features/dashboard/components/dashboard-header.tsx
+++ b/src/features/dashboard/components/dashboard-header.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Menu, Sparkles } from "lucide-react";
+import type { DashboardOverview } from "../types";
+
+export interface DashboardHeaderProps {
+  farm: DashboardOverview["farm"];
+  sensorStatus: DashboardOverview["sensorStatus"];
+  onMenuToggle?: () => void;
+  className?: string;
+}
+
+export function DashboardHeader({
+  farm,
+  sensorStatus,
+  onMenuToggle,
+  className,
+}: DashboardHeaderProps) {
+  return (
+    <Card
+      className={cn(
+        "border-dashed bg-gradient-to-br from-background via-background to-background/70 backdrop-blur",
+        className,
+      )}
+    >
+      <CardHeader className="flex flex-col gap-4 pb-0 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            onClick={onMenuToggle}
+            aria-label="Abrir menu de navegação"
+            className="shrink-0"
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+          <div className="space-y-1">
+            <CardTitle className="text-2xl font-semibold tracking-tight sm:text-3xl">
+              {farm.name}
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">{farm.location}</p>
+          </div>
+        </div>
+        <Badge variant="outline" className="flex items-center gap-1">
+          <Sparkles className="h-3.5 w-3.5" />
+          Safra {farm.harvestSeason}
+        </Badge>
+      </CardHeader>
+      <CardContent className="grid gap-4 pt-6 sm:grid-cols-2 lg:grid-cols-4">
+        <dl className="space-y-1 rounded-lg border border-border/70 bg-muted/40 p-3">
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Gerente</dt>
+          <dd className="text-sm font-semibold text-foreground">{farm.manager}</dd>
+        </dl>
+        <dl className="space-y-1 rounded-lg border border-border/70 bg-muted/40 p-3">
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Última sincronização</dt>
+          <dd className="text-sm font-semibold text-foreground">{farm.lastSync}</dd>
+        </dl>
+        <dl className="space-y-1 rounded-lg border border-border/70 bg-muted/40 p-3">
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Fuso horário</dt>
+          <dd className="text-sm font-semibold text-foreground">{farm.timezone}</dd>
+        </dl>
+        <dl className="space-y-1 rounded-lg border border-border/70 bg-muted/40 p-3">
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Sensores ativos</dt>
+          <dd className="text-sm font-semibold text-foreground">
+            {sensorStatus.online} / {sensorStatus.totalSensors}
+          </dd>
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/dashboard/components/metric-card.tsx
+++ b/src/features/dashboard/components/metric-card.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  ArrowDownRight,
+  ArrowRight,
+  ArrowUpRight,
+  CircleDot,
+  Droplet,
+  Sparkles,
+  Thermometer,
+  type LucideIcon,
+} from "lucide-react";
+import type { DashboardMetric } from "../types";
+
+export type MetricCardTone = "neutral" | "info" | "success" | "warning" | "danger";
+
+export interface MetricCardProps {
+  metric: DashboardMetric;
+  tone?: MetricCardTone;
+  icon?: LucideIcon;
+  className?: string;
+}
+
+const toneClasses: Record<MetricCardTone, string> = {
+  neutral: "border-border bg-background",
+  info: "border-sky-500/40 bg-sky-500/5",
+  success: "border-emerald-500/40 bg-emerald-500/5",
+  warning: "border-amber-500/40 bg-amber-500/5",
+  danger: "border-rose-500/40 bg-rose-500/5",
+};
+
+export function MetricCard({ metric, tone = "neutral", icon, className }: MetricCardProps) {
+  const Icon = icon ?? inferIcon(metric);
+  const TrendIcon = trendIcon(metric.trend.direction);
+
+  return (
+    <Card className={cn("h-full overflow-hidden border backdrop-blur", toneClasses[tone], className)}>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+        <div>
+          <CardDescription className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">
+            {metric.label}
+          </CardDescription>
+          <CardTitle className="mt-2 text-2xl font-semibold">
+            {formatMetricValue(metric.value, metric.unit)}
+            {metric.unit && <span className="ml-1 text-base font-medium text-muted-foreground">{metric.unit}</span>}
+          </CardTitle>
+        </div>
+        <span className="rounded-full border border-border bg-background/70 p-2">
+          <Icon className="h-5 w-5" />
+        </span>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-muted-foreground">
+        {metric.description && <p>{metric.description}</p>}
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="flex items-center gap-1 border-dashed text-xs">
+            <TrendIcon className="h-3.5 w-3.5" />
+            {formatTrendValue(metric.trend.value, metric.trend.valueType)}
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            {metric.trend.direction === "stable"
+              ? `Estável versus ${metric.trend.comparedTo}`
+              : `Comparado a ${metric.trend.comparedTo}`}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function inferIcon(metric: DashboardMetric): LucideIcon {
+  if (metric.unit?.includes("°")) {
+    return Thermometer;
+  }
+
+  if (metric.unit?.includes("%")) {
+    return Droplet;
+  }
+
+  if (metric.label.toLowerCase().includes("alerta")) {
+    return CircleDot;
+  }
+
+  return Sparkles;
+}
+
+function trendIcon(direction: DashboardMetric["trend"]["direction"]): LucideIcon {
+  switch (direction) {
+    case "up":
+      return ArrowUpRight;
+    case "down":
+      return ArrowDownRight;
+    default:
+      return ArrowRight;
+  }
+}
+
+function formatMetricValue(value: number, unit?: string) {
+  const formatted = new Intl.NumberFormat("pt-BR", {
+    maximumFractionDigits: unit && unit.includes("°") ? 1 : 0,
+  }).format(value);
+
+  return formatted;
+}
+
+function formatTrendValue(value: number, valueType: DashboardMetric["trend"]["valueType"]) {
+  if (valueType === "percentage") {
+    return `${value > 0 ? "+" : value < 0 ? "" : "±"}${value}%`;
+  }
+
+  return `${value > 0 ? "+" : value < 0 ? "" : "±"}${value}`;
+}

--- a/src/features/dashboard/components/monthly-alerts-card.tsx
+++ b/src/features/dashboard/components/monthly-alerts-card.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { PieChart } from "lucide-react";
+import type { MonthlyAlertBreakdown } from "../types";
+
+export interface MonthlyAlertsCardProps {
+  alerts: MonthlyAlertBreakdown[];
+  className?: string;
+}
+
+export function MonthlyAlertsCard({ alerts, className }: MonthlyAlertsCardProps) {
+  const totals = alerts.reduce(
+    (acc, month) => {
+      acc.total += month.total;
+      acc.critical += month.critical;
+      acc.warning += month.warning;
+      acc.resolved += month.resolved;
+      return acc;
+    },
+    { total: 0, critical: 0, warning: 0, resolved: 0 },
+  );
+
+  return (
+    <Card className={cn("h-full border bg-background backdrop-blur", className)}>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="text-lg font-semibold leading-tight">Alertas Mensais</CardTitle>
+          <CardDescription className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">
+            Distribuição por severidade e status
+          </CardDescription>
+        </div>
+        <span className="rounded-full border border-border bg-muted/40 p-2">
+          <PieChart className="h-5 w-5" />
+        </span>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-muted-foreground">
+          <Badge variant="secondary" className="bg-muted/40">
+            Total {totals.total}
+          </Badge>
+          <Badge variant="secondary" className="bg-rose-500/10 text-rose-600 dark:text-rose-300">
+            Críticos {totals.critical}
+          </Badge>
+          <Badge variant="secondary" className="bg-amber-500/10 text-amber-600 dark:text-amber-300">
+            Alertas {totals.warning}
+          </Badge>
+          <Badge variant="secondary" className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-300">
+            Resolvidos {totals.resolved}
+          </Badge>
+        </div>
+        <ul className="space-y-3">
+          {alerts.map((month) => {
+            const total = Math.max(month.total, 1);
+            const segments = [
+              { label: "critical", value: month.critical, className: "bg-rose-500/70" },
+              { label: "warning", value: month.warning, className: "bg-amber-500/70" },
+              { label: "resolved", value: month.resolved, className: "bg-emerald-500/70" },
+            ] as const;
+
+            return (
+              <li key={month.month} className="rounded-lg border border-border/60 bg-muted/30 p-3">
+                <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+                  <span>{month.month}</span>
+                  <span>{month.total} alertas</span>
+                </div>
+                <div className="mt-2 flex h-2 w-full overflow-hidden rounded-full bg-background/60">
+                  {segments.map((segment) => (
+                    <span
+                      key={segment.label}
+                      className={cn("h-full", segment.className)}
+                      style={{ width: `${(segment.value / total) * 100}%` }}
+                    />
+                  ))}
+                </div>
+                <div className="mt-2 grid grid-cols-3 gap-2 text-[10px] font-semibold text-muted-foreground/80">
+                  <span className="flex items-center gap-1">
+                    <span className="h-2 w-2 rounded-full bg-rose-500/80" /> Críticos {month.critical}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="h-2 w-2 rounded-full bg-amber-500/80" /> Alertas {month.warning}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="h-2 w-2 rounded-full bg-emerald-500/80" /> Resolvidos {month.resolved}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/dashboard/components/status-banner.tsx
+++ b/src/features/dashboard/components/status-banner.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { AlertTriangle, CircleDot } from "lucide-react";
+import type { DashboardOverview } from "../types";
+
+export type StatusBannerVariant = "ok" | "warning";
+
+export interface StatusBannerProps {
+  sensorStatus: DashboardOverview["sensorStatus"];
+  variant?: StatusBannerVariant;
+  message?: string;
+  className?: string;
+}
+
+export function StatusBanner({
+  sensorStatus,
+  variant = "ok",
+  message,
+  className,
+}: StatusBannerProps) {
+  const variantStyles: Record<StatusBannerVariant, string> = {
+    ok: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
+    warning: "border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-100",
+  };
+
+  const Icon = variant === "warning" ? AlertTriangle : CircleDot;
+
+  return (
+    <Card
+      className={cn(
+        "flex flex-col gap-3 rounded-xl border px-4 py-3 transition-all sm:flex-row sm:items-center sm:justify-between",
+        variantStyles[variant],
+        className,
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 rounded-full border border-current/40 bg-background/40 p-1">
+          <Icon className="h-4 w-4" />
+        </span>
+        <div className="space-y-1">
+          <p className="text-sm font-semibold leading-tight">
+            {message ??
+              (variant === "warning"
+                ? "Atenção: Verifique os sensores com anomalias detectadas."
+                : "Todos os sistemas estão operando dentro dos parâmetros esperados.")}
+          </p>
+          <p className="text-xs text-current/80">
+            Gateway {sensorStatus.gatewayStatus} · Sinal médio {sensorStatus.averageSignalQuality}% · {sensorStatus.online} sensores online
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-xs font-medium">
+        <Badge variant="secondary" className="bg-background/40 text-current">
+          {sensorStatus.offline} offline
+        </Badge>
+        <Badge variant="secondary" className="bg-background/40 text-current">
+          {sensorStatus.maintenance} manutenção
+        </Badge>
+        <Badge variant="secondary" className="bg-background/40 text-current">
+          {sensorStatus.batteryCritical} bateria crítica
+        </Badge>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add shadcn-style button, badge, and card primitives for reuse across the dashboard
- introduce dashboard header, status banner, metric, critical alert, and monthly alerts cards with typed props and lucide icons
- support tone and variant styling plus className overrides for flexible layout composition

## Testing
- npm run lint *(fails: ESLint config "prettier" is missing)*


------
https://chatgpt.com/codex/tasks/task_e_68e47c778b50832b8e1c46994ef56d6b