### PR TITLE
Add dashboard accessibility tests and docs

### DIFF
--- a/docs/dashboard-overview.md
+++ b/docs/dashboard-overview.md
@@ -1,0 +1,44 @@
+# Dashboard – Visão Geral de Implementação
+
+Este documento descreve como o dashboard da rota `/dashboard` foi estruturado, seus componentes principais e o fluxo de dados mockado utilizado durante o desenvolvimento.
+
+## Estrutura de componentes
+
+| Componente | Localização | Responsabilidades principais |
+|------------|-------------|------------------------------|
+| `DashboardPage` | `src/app/dashboard/page.tsx` | Composição geral da página. Carrega os dados via `useDashboardOverview`, deriva o estado do banner e distribui métricas, alertas e o detalhamento mensal. |
+| `DashboardHeader` | `src/features/dashboard/components/dashboard-header.tsx` | Exibe informações da fazenda (nome, safra, localização) e um resumo de sensores online/offline. Recebe `farm` e `sensorStatus` como props. |
+| `StatusBanner` | `src/features/dashboard/components/status-banner.tsx` | Banner de estado com região viva (`role="status"`) e badges com contagem de sensores por estado. Props: `sensorStatus`, `variant`, `message` e `className`. |
+| `MetricCard` | `src/features/dashboard/components/metric-card.tsx` | Card de KPI com ícone inferido automaticamente, destaque de tendência e descrição. Props: `metric`, `tone`, `icon`, `className`. |
+| `CriticalAlertCard` | `src/features/dashboard/components/critical-alert-card.tsx` | Card para cada alerta crítico com resumo, recomendações e botões opcionais de ação (`onAcknowledge`, `onResolve`). |
+| `MonthlyAlertsCard` | `src/features/dashboard/components/monthly-alerts-card.tsx` | Representa a distribuição mensal de alertas (gráfico/visualização). Recebe `alerts` como prop. |
+
+### Interatividade e acessibilidade
+
+- As métricas são renderizadas como botões acessíveis (`role="button"`, `aria-label` e foco visível) que, no momento, disparam logs de intenção via `console.info`.
+- O botão "Ver todos" dos alertas críticos possui `aria-label="Ver todos os alertas críticos"` e pode ser conectado a uma rota futura.
+- O banner de status possui `role="status"` e `aria-live` dinâmico (`assertive` para falhas críticas), permitindo leitura por leitores de tela quando houver mudança de estado.
+
+## Fluxo de dados mockado
+
+1. **Mocks tipados** – O arquivo `src/features/dashboard/mocks.ts` exporta `dashboardOverviewMock`, objeto que segue o contrato definido em `src/features/dashboard/types.ts`.
+2. **Hook de dados** – `useDashboardOverview` (`src/features/dashboard/hooks/use-dashboard-overview.ts`) inicializa o estado com o mock, fornece funções `refresh`/`refetch` (promessas resolvendo para o mock) e flags `isLoading`/`isError`.
+3. **Consumo na página** – `DashboardPage` usa o hook para obter `data`. Caso `data` seja `null`, nada é renderizado. Quando existe valor, a página deriva `bannerVariant`/`bannerMessage` conforme `sensorsStatus` e contadores de sensores offline ou com bateria crítica.
+4. **Atualização periódica** – Um `setInterval` em `DashboardPage` chama `refresh()` a cada 60 segundos. Para trocar o mock por uma chamada real, substitua o corpo de `refetch` por uma requisição HTTP/fetch e mantenha `refresh` como atalho.
+
+### Como atualizar os mocks
+
+1. Ajuste ou acrescente campos nos tipos em `types.ts`.
+2. Atualize `dashboardOverviewMock` garantindo aderência ao novo contrato.
+3. Se precisar simular estados específicos (ex.: ausência de alertas críticos), crie variantes exportadas adicionais em `mocks.ts`.
+4. Caso o hook passe a consumir API real, mantenha os mocks como fallback para testes e Storybook (exportando-os separadamente).
+
+## Testes e validações
+
+- **React Testing Library** – Os testes em `src/features/dashboard/__tests__/dashboard-page.test.tsx` cobrem:
+  - Renderização das métricas como controles acessíveis e resposta ao clique.
+  - Banner de status com região viva e contagens de sensores.
+  - Lista de alertas críticos, ação de "Ver todos" e estado vazio.
+- **Tokens de cor** – O arquivo `src/styles/__tests__/color-contrast.test.ts` valida o contraste mínimo (AA) entre pares de variáveis de cor nos temas claro e escuro (`background`, `muted`, `secondary`, `accent` e `destructive`).
+
+Para executar os testes, utilize `npm run test` (Vitest + jsdom). O arquivo `vitest.setup.ts` configura o ambiente, inclui asserções do `@testing-library/jest-dom` e silencia warnings durante a suíte.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "vitest"
   },
   "dependencies": {
     "next": "14.2.4",
@@ -23,13 +24,22 @@
     "@types/node": "20.14.10",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
+    "@testing-library/dom": "9.3.4",
+    "@testing-library/jest-dom": "6.4.6",
+    "@testing-library/react": "14.3.1",
+    "@testing-library/user-event": "14.5.2",
+    "@types/testing-library__jest-dom": "6.0.0",
+    "@vitejs/plugin-react": "4.3.1",
     "autoprefixer": "10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.4",
     "eslint-config-prettier": "9.1.0",
+    "jsdom": "24.0.0",
     "postcss": "8.4.39",
     "prettier": "3.3.2",
     "tailwindcss": "3.4.4",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "vite": "5.3.4",
+    "vitest": "1.6.0"
   }
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -107,6 +107,7 @@ export default function DashboardPage() {
                   key={metricKey}
                   role="button"
                   tabIndex={0}
+                  aria-label={`Ver detalhes da métrica ${metric.label}`}
                   onClick={() => handleMetricSelect(metricKey)}
                   onKeyDown={(event) => {
                     if (event.key === "Enter" || event.key === " ") {
@@ -114,7 +115,7 @@ export default function DashboardPage() {
                       handleMetricSelect(metricKey);
                     }
                   }}
-                  className="group cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  className="group cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
                   <MetricCard
                     metric={metric}
@@ -140,7 +141,12 @@ export default function DashboardPage() {
                 Atividades que exigem atenção imediata
               </h2>
             </div>
-            <Button type="button" variant="outline" onClick={handleViewAllAlerts}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleViewAllAlerts}
+              aria-label="Ver todos os alertas críticos"
+            >
               Ver todos
             </Button>
           </div>

--- a/src/features/dashboard/__tests__/dashboard-page.test.tsx
+++ b/src/features/dashboard/__tests__/dashboard-page.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DashboardPage from "@/app/dashboard/page";
+import { dashboardOverviewMock } from "@/features/dashboard/mocks";
+import { useDashboardOverview } from "@/features/dashboard/hooks/use-dashboard-overview";
+import type { DashboardOverview } from "@/features/dashboard/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/dashboard/hooks/use-dashboard-overview");
+
+const mockUseDashboardOverview = vi.mocked(useDashboardOverview);
+
+type DashboardOverviewHookResult = {
+  data: DashboardOverview | null;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => Promise<DashboardOverview>;
+  refresh: () => Promise<DashboardOverview>;
+};
+
+function createHookResult(data: DashboardOverview): DashboardOverviewHookResult {
+  return {
+    data,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(data),
+    refresh: vi.fn().mockResolvedValue(data),
+  };
+}
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockUseDashboardOverview.mockReturnValue(createHookResult(structuredClone(dashboardOverviewMock)));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("renders KPI metrics with accessible controls", async () => {
+    const user = userEvent.setup();
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    render(<DashboardPage />);
+
+    Object.values(dashboardOverviewMock.metrics).forEach((metric) => {
+      expect(screen.getByRole("button", { name: `Ver detalhes da métrica ${metric.label}` })).toBeInTheDocument();
+    });
+
+    const monitoredSilosButton = screen.getByRole("button", {
+      name: `Ver detalhes da métrica ${dashboardOverviewMock.metrics.monitoredSilos.label}`,
+    });
+
+    await user.click(monitoredSilosButton);
+
+    expect(consoleSpy).toHaveBeenCalledWith("Selecionar métrica para detalhamento futuro:", "monitoredSilos");
+
+    consoleSpy.mockRestore();
+  });
+
+  it("announces the current sensor status through a live region", () => {
+    render(<DashboardPage />);
+
+    const banner = screen.getByRole("status");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+    expect(banner).toHaveTextContent("Atenção: Verifique os sensores com anomalias detectadas.");
+    expect(banner).toHaveTextContent("6 offline");
+    expect(banner).toHaveTextContent("6 manutenção");
+    expect(banner).toHaveTextContent("4 bateria crítica");
+  });
+
+  it("exibe os alertas críticos e permite navegar para a lista completa", async () => {
+    const user = userEvent.setup();
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    render(<DashboardPage />);
+
+    dashboardOverviewMock.criticalAlerts.forEach((alert) => {
+      expect(screen.getByText(alert.alertType)).toBeInTheDocument();
+      expect(screen.getByText(alert.description)).toBeInTheDocument();
+    });
+
+    const viewAllButton = screen.getByRole("button", { name: "Ver todos os alertas críticos" });
+    await user.click(viewAllButton);
+
+    expect(consoleSpy).toHaveBeenCalledWith("Navegar para a lista completa de alertas críticos");
+
+    consoleSpy.mockRestore();
+  });
+
+  it("mostra estado vazio quando não há alertas críticos ativos", () => {
+    const emptyOverview: DashboardOverview = {
+      ...structuredClone(dashboardOverviewMock),
+      criticalAlerts: [],
+    };
+
+    mockUseDashboardOverview.mockReturnValueOnce(createHookResult(emptyOverview));
+
+    render(<DashboardPage />);
+
+    expect(screen.getByText("Nenhum alerta crítico ativo")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Os sensores não registraram alertas críticos recentemente. Continue monitorando para reagir rapidamente a novas ocorrências.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard/components/critical-alert-card.tsx
+++ b/src/features/dashboard/components/critical-alert-card.tsx
@@ -59,12 +59,21 @@ export function CriticalAlertCard({
         </p>
         <div className="flex flex-wrap gap-2">
           {onAcknowledge && (
-            <Button size="sm" variant="outline" onClick={() => onAcknowledge(alert)}>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onAcknowledge(alert)}
+              aria-label={`Registrar reconhecimento para ${alert.siloName}`}
+            >
               Registrar reconhecimento
             </Button>
           )}
           {onResolve && (
-            <Button size="sm" onClick={() => onResolve(alert)}>
+            <Button
+              size="sm"
+              onClick={() => onResolve(alert)}
+              aria-label={`Marcar como resolvido o alerta de ${alert.siloName}`}
+            >
               Marcar como resolvido
             </Button>
           )}

--- a/src/features/dashboard/components/status-banner.tsx
+++ b/src/features/dashboard/components/status-banner.tsx
@@ -34,9 +34,13 @@ export function StatusBanner({
   };
 
   const Icon = variant === "ok" ? CircleDot : AlertTriangle;
+  const liveRegionMode = variant === "danger" ? "assertive" : "polite";
 
   return (
     <Card
+      role="status"
+      aria-live={liveRegionMode}
+      aria-atomic="true"
       className={cn(
         "flex flex-col gap-3 rounded-xl border px-4 py-3 transition-all sm:flex-row sm:items-center sm:justify-between",
         variantStyles[variant],

--- a/src/styles/__tests__/color-contrast.test.ts
+++ b/src/styles/__tests__/color-contrast.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type HSL = [number, number, number];
+
+const cssContent = readFileSync(path.resolve(__dirname, "../../styles/globals.css"), "utf8");
+
+function extractTokens(block: string): Record<string, HSL> {
+  const tokens: Record<string, HSL> = {};
+  const tokenRegex = /--([\w-]+):\s*([\d.]+)\s+([\d.]+)%\s+([\d.]+)%/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenRegex.exec(block)) !== null) {
+    const [, name, h, s, l] = match;
+    tokens[name] = [Number(h), Number(s), Number(l)];
+  }
+
+  return tokens;
+}
+
+function hslToRgb([h, s, l]: HSL): [number, number, number] {
+  s /= 100;
+  l /= 100;
+
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+
+  return [f(0), f(8), f(4)].map((channel) => Math.round(channel * 255)) as [number, number, number];
+}
+
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const normalize = (value: number) => {
+    const scaled = value / 255;
+    return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+  };
+
+  const [nr, ng, nb] = [r, g, b].map(normalize) as [number, number, number];
+
+  return 0.2126 * nr + 0.7152 * ng + 0.0722 * nb;
+}
+
+function contrastRatio(background: HSL, foreground: HSL): number {
+  const bgLuminance = relativeLuminance(hslToRgb(background));
+  const fgLuminance = relativeLuminance(hslToRgb(foreground));
+  const lighter = Math.max(bgLuminance, fgLuminance);
+  const darker = Math.min(bgLuminance, fgLuminance);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+const rootBlock = cssContent.match(/:root\s*{([\s\S]*?)}/);
+const darkBlock = cssContent.match(/\.dark\s*{([\s\S]*?)}/);
+
+if (!rootBlock || !darkBlock) {
+  throw new Error("Não foi possível localizar os tokens de cor em globals.css");
+}
+
+const rootTokens = extractTokens(rootBlock[1]);
+const darkTokens = extractTokens(darkBlock[1]);
+
+const combinations: Array<{ background: string; foreground: string; minimum: number }> = [
+  { background: "background", foreground: "foreground", minimum: 4.5 },
+  { background: "secondary", foreground: "secondary-foreground", minimum: 4.5 },
+  { background: "muted", foreground: "muted-foreground", minimum: 4.5 },
+  { background: "accent", foreground: "accent-foreground", minimum: 4.5 },
+  { background: "destructive", foreground: "destructive-foreground", minimum: 4.5 },
+];
+
+describe("Tokens de cor", () => {
+  it("garantem contraste mínimo no tema claro", () => {
+    combinations.forEach(({ background, foreground, minimum }) => {
+      const ratio = contrastRatio(rootTokens[background], rootTokens[foreground]);
+      expect(ratio).toBeGreaterThanOrEqual(minimum);
+    });
+  });
+
+  it("garantem contraste mínimo no tema escuro", () => {
+    combinations.forEach(({ background, foreground, minimum }) => {
+      const ratio = contrastRatio(darkTokens[background], darkTokens[foreground]);
+      expect(ratio).toBeGreaterThanOrEqual(minimum);
+    });
+  });
+});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,12 +20,12 @@
     --secondary-foreground: 222.2 47.4% 11.2%;
 
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted-foreground: 215.4 16.3% 38%;
 
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
 
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 84.2% 46%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 214.3 31.8% 91.4%;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    css: true,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      "@/components": path.resolve(__dirname, "./src/components"),
+      "@/lib": path.resolve(__dirname, "./src/lib"),
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,23 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
+import type { SpyInstance } from "vitest";
+
+// Garantir limpeza do DOM entre os testes
+afterEach(() => {
+  cleanup();
+});
+
+// Evitar ruído de logs em testes
+let errorSpy: SpyInstance | undefined;
+let warnSpy: SpyInstance | undefined;
+
+beforeAll(() => {
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterAll(() => {
+  errorSpy?.mockRestore();
+  warnSpy?.mockRestore();
+});


### PR DESCRIPTION
## Summary
- add Vitest and React Testing Library configuration with coverage for dashboard metrics, status banner, and critical alerts
- improve accessibility with live status banner, labelled buttons, focus styles, and higher-contrast design tokens
- document the dashboard component hierarchy, props, and mock update workflow in `docs/dashboard-overview.md`
- validate light/dark design token contrast through automated tests

## Testing
- npm run test *(blocked: npm registry returned HTTP 403 for @testing-library/dom in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e480f72548832bad1ce26912f4d740