### PR TITLE
feat: implement sidebar layout

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,7 +10,6 @@ import { StatusBanner } from "@/features/dashboard/components/status-banner";
 import { CriticalAlertCard } from "@/features/dashboard/components/critical-alert-card";
 import { useDashboardOverview } from "@/features/dashboard/hooks/use-dashboard-overview";
 import type { DashboardMetrics } from "@/features/dashboard/types";
-import { Header } from "@/components/header";
 
 function EmptyState({ title, description }: { title: string; description: string }) {
   return (
@@ -83,8 +82,7 @@ export default function DashboardPage() {
   };
 
   return (
-    <main className="min-h-screen bg-muted/20 py-10">
-      <Header />
+    <div className="py-10">
       <div className="container mx-auto flex w-full flex-col gap-6 px-4 sm:px-6 lg:px-8">
         <DashboardHeader farm={farm} sensorStatus={sensorStatus} />
         <StatusBanner
@@ -182,6 +180,6 @@ export default function DashboardPage() {
           </div>
         </section>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,9 @@ import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "@/styles/globals.css";
-import { SidebarProvider } from "@/components/ui/sidebar";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
+import { Header } from "@/components/header";
 
 type RootLayoutProps = Readonly<{
   children: ReactNode;
@@ -23,8 +24,15 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html lang="pt-BR">
       <body className={inter.className}>
         <SidebarProvider>
-          <AppSidebar />
-          {children}
+          <div className="flex min-h-screen w-full bg-background">
+            <AppSidebar />
+            <SidebarInset className="flex min-h-screen flex-1 flex-col bg-muted/20">
+              <Header />
+              <div className="flex-1 overflow-y-auto">
+                {children}
+              </div>
+            </SidebarInset>
+          </div>
         </SidebarProvider>
       </body>
     </html>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,20 +1,139 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import {
+  LayoutDashboard,
+  Activity,
+  AlertTriangle,
+  BarChart3,
+  Settings,
+  Leaf,
+} from "lucide-react"
+
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
 } from "@/components/ui/sidebar"
 
+const navigationItems = [
+  {
+    title: "Visão geral",
+    href: "/dashboard",
+    icon: LayoutDashboard,
+  },
+  {
+    title: "Safras monitoradas",
+    href: "/safras",
+    icon: Leaf,
+    comingSoon: true,
+  },
+  {
+    title: "Monitoramento em tempo real",
+    href: "/monitoramento",
+    icon: Activity,
+    comingSoon: true,
+  },
+  {
+    title: "Alertas e ocorrências",
+    href: "/alertas",
+    icon: AlertTriangle,
+    comingSoon: true,
+  },
+  {
+    title: "Relatórios",
+    href: "/relatorios",
+    icon: BarChart3,
+    comingSoon: true,
+  },
+  {
+    title: "Configurações",
+    href: "/configuracoes",
+    icon: Settings,
+    comingSoon: true,
+  },
+]
+
 export function AppSidebar() {
+  const pathname = usePathname()
+
   return (
     <Sidebar>
-      <SidebarHeader />
+      <SidebarHeader className="border-b border-sidebar-border px-4 py-3">
+        <Link href="/dashboard" className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-base font-semibold text-primary-foreground">
+            GS
+          </div>
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold text-sidebar-foreground">
+              GrãoSeguro
+            </span>
+            <span className="text-xs text-sidebar-foreground/70">
+              Monitoramento agrícola
+            </span>
+          </div>
+        </Link>
+      </SidebarHeader>
       <SidebarContent>
-        <SidebarGroup />
-        <SidebarGroup />
+        <SidebarGroup>
+          <SidebarGroupLabel>Menu principal</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {navigationItems.map((item) => {
+                const Icon = item.icon
+                const isActive =
+                  !item.comingSoon &&
+                  (pathname === item.href || pathname.startsWith(`${item.href}/`))
+
+                return (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton
+                      asChild={!item.comingSoon}
+                      disabled={item.comingSoon}
+                      aria-disabled={item.comingSoon || undefined}
+                      tooltip={item.title}
+                      isActive={isActive}
+                      className={item.comingSoon ? "text-sidebar-foreground/70" : undefined}
+                    >
+                      {item.comingSoon ? (
+                        <span className="flex items-center gap-2">
+                          <Icon className="size-4" aria-hidden="true" />
+                          <span>{item.title}</span>
+                        </span>
+                      ) : (
+                        <Link href={item.href} className="flex items-center gap-2">
+                          <Icon className="size-4" aria-hidden="true" />
+                          <span>{item.title}</span>
+                        </Link>
+                      )}
+                    </SidebarMenuButton>
+                    {item.comingSoon ? (
+                      <SidebarMenuBadge className="bg-muted text-xs font-medium text-muted-foreground">
+                        Em breve
+                      </SidebarMenuBadge>
+                    ) : null}
+                  </SidebarMenuItem>
+                )
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter />
+      <SidebarFooter className="border-t border-sidebar-border px-4 py-3 text-xs text-sidebar-foreground/70">
+        <p className="font-medium">Silo Monitor</p>
+        <p className="text-[11px]">Última atualização em tempo real</p>
+      </SidebarFooter>
+      <SidebarRail />
     </Sidebar>
   )
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,11 +1,39 @@
-import { SidebarTrigger } from "./ui/sidebar";
+"use client"
 
-export function Header(){
-    return (
-        <header className="flex items-center justify-between p-4 border-b">
-            <SidebarTrigger/>
-            <h1 className="text-lg font-semibold">GrãoSeguro Dashboard</h1>
-            <div></div> {/* Placeholder para alinhamento */}
-        </header>
-    )
+import Link from "next/link"
+import { Bell } from "lucide-react"
+
+import { Button } from "./ui/button"
+import { SidebarTrigger } from "./ui/sidebar"
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-border bg-background/95 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="flex items-center gap-3">
+        <SidebarTrigger className="text-muted-foreground" />
+        <Link href="/dashboard" className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+            GS
+          </div>
+          <div className="flex flex-col leading-tight">
+            <span className="text-sm font-semibold text-foreground">GrãoSeguro</span>
+            <span className="text-xs text-muted-foreground">Silo Monitor</span>
+          </div>
+        </Link>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Abrir notificações"
+        className="relative text-muted-foreground hover:text-foreground"
+      >
+        <Bell className="h-5 w-5" aria-hidden="true" />
+        <span className="absolute right-2 top-2 flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-destructive opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-destructive" />
+        </span>
+      </Button>
+    </header>
+  )
 }


### PR DESCRIPTION
## Summary
- add a branded sidebar with grouped navigation items and active state handling
- introduce a shared header with sidebar trigger, branding and notifications icon
- wrap app layout with the sidebar inset and reuse shared spacing in dashboard page

## Testing
- pnpm lint *(fails: ESLint couldn't find the "prettier" config referenced in .eslintrc.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e4940d67e8832badb7f8acd78b8092